### PR TITLE
fixed schedule bugs + added guards against already published schedules

### DIFF
--- a/app/src/components/schedule/AvailabilityInput.tsx
+++ b/app/src/components/schedule/AvailabilityInput.tsx
@@ -33,7 +33,8 @@ const updateSchedule = (
   },
   newData: RouterOutputs["schedule"]["getScheduleFromSlugId"]
 ) => {
-  const prevAttendees = newData?.attendees as UserAvailability[];
+  // if attendees is null, just set it to an empty array
+  const prevAttendees = (newData?.attendees ?? []) as UserAvailability[];
   const updatedAvailability = JSON.parse(
     variables.attendee
   ) as UserAvailability;

--- a/app/src/components/schedule/PublishedEventsNote.tsx
+++ b/app/src/components/schedule/PublishedEventsNote.tsx
@@ -1,0 +1,23 @@
+import Typography from "@ui/Typography";
+import Link from "next/link";
+
+interface PublishedEventsNoteProps {
+  slug: string;
+}
+
+function PublishedEventsNote({ slug }: PublishedEventsNoteProps) {
+  return (
+    <div className="mx-8 rounded-lg bg-neutral-300 p-4">
+      <Typography>
+        Events have already been published for this schedule! View them{" "}
+        <span>
+          {/* TODO: replace this with custom link component. */}
+          <Link href={`/schedule/${slug}`}>here</Link>
+        </span>
+        .
+      </Typography>
+    </div>
+  );
+}
+
+export default PublishedEventsNote;

--- a/app/src/pages/create.tsx
+++ b/app/src/pages/create.tsx
@@ -17,7 +17,11 @@ import BackArrow from "../components/shared/BackArrow";
 import Loading from "../components/shared/Loading";
 import ModalBackground from "../components/shared/ModalBackground";
 import Unauthenticated from "../components/shared/Unauthenticated";
-import { getTimeOptions, MINUTES, MAX_DESCRIPTION_LENGTH } from "../utils/formUtils";
+import {
+  getTimeOptions,
+  MAX_DESCRIPTION_LENGTH,
+  MINUTES,
+} from "../utils/formUtils";
 import { createSlug } from "../utils/scheduleUtils";
 import { trpc } from "../utils/trpc";
 
@@ -52,7 +56,10 @@ type ControlledScheduleInputs = {
 
 const CreateScheduleSchema = z.object({
   scheduleName: z.string().min(1, "Schedule name is required!"),
-  description: z.string().max(200, "Description cannot be longer than 200 characters.").optional(),
+  description: z
+    .string()
+    .max(200, "Description cannot be longer than 200 characters.")
+    .optional(),
   dateRange: z
     .object({
       startDate: z
@@ -151,12 +158,12 @@ function Create() {
         onSuccess: (data) => {
           const { name: currentName, id } = data.schedule;
           const slug = createSlug(currentName, id);
+          router.push(`schedule/${slug}`);
           setNoticeMessage({
             action: "close",
             icon: "check",
             message: "Your schedule has been successfully created!",
           });
-          router.push(`schedule/${slug}`);
         },
       }
     );
@@ -222,7 +229,11 @@ function Create() {
           required
         />
         {/* TODO: add tinymce integration */}
-        <Form.TextArea name="description" displayName="Description" maxLength={MAX_DESCRIPTION_LENGTH} />
+        <Form.TextArea
+          name="description"
+          displayName="Description"
+          maxLength={MAX_DESCRIPTION_LENGTH}
+        />
 
         <div className="relative rounded-lg bg-neutral-300 p-4">
           {defaultValues.dateRange.isOneDay && (

--- a/app/src/pages/schedule/[slug]/availability.tsx
+++ b/app/src/pages/schedule/[slug]/availability.tsx
@@ -3,6 +3,7 @@ import { useSession } from "next-auth/react";
 import { useRouter } from "next/router";
 import AvailabilityInput from "../../../components/schedule/AvailabilityInput";
 import AvailabilityResponses from "../../../components/schedule/AvailabilityResponses";
+import PublishedEventsNote from "../../../components/schedule/PublishedEventsNote";
 import ScheduleHeader from "../../../components/schedule/ScheduleHeader";
 import BackArrow from "../../../components/shared/BackArrow";
 import Loading from "../../../components/shared/Loading";
@@ -19,6 +20,11 @@ function Availability() {
 
   if (!router.isReady || isScheduleLoading || isUserAvailabilityLoading) {
     return <Loading />;
+  }
+
+  // show a message if events have already been made for this schedule
+  if (schedule && schedule.events.length > 0) {
+    return <PublishedEventsNote slug={slug} />;
   }
 
   return (

--- a/app/src/pages/schedule/[slug]/index.tsx
+++ b/app/src/pages/schedule/[slug]/index.tsx
@@ -20,12 +20,14 @@ import { getHost } from "../../../utils/scheduleUtils";
 
 type SchedulePageAvailabilityProps = AvailabilityProps & {
   buttonTitle: string;
+  hasEvents: boolean;
 };
 
 function AvailabilitySection({
   schedule,
   slug,
   buttonTitle,
+  hasEvents,
 }: SchedulePageAvailabilityProps) {
   return (
     <div className="my-8 w-full bg-neutral-300 py-8 px-8">
@@ -33,10 +35,12 @@ function AvailabilitySection({
         Availability
       </Typography>
       <AvailabilityResponses schedule={schedule} />
-      <Button href={`/schedule/${slug}/availability`}>
-        <FiEdit />
-        {buttonTitle}
-      </Button>
+      {!hasEvents && (
+        <Button href={`/schedule/${slug}/availability`}>
+          <FiEdit />
+          {buttonTitle}
+        </Button>
+      )}
     </div>
   );
 }
@@ -160,7 +164,9 @@ function SchedulePage() {
               </Typography>
             </div>
           )}
-          {isHost && numberOfAttendees > 0 && <PublishSection slug={slug} />}
+          {isHost && !hasEvents && numberOfAttendees > 0 && (
+            <PublishSection slug={slug} />
+          )}
         </div>
 
         {schedule && (
@@ -168,6 +174,7 @@ function SchedulePage() {
             schedule={schedule}
             slug={slug}
             buttonTitle={availabilityButtonTitle}
+            hasEvents={hasEvents}
           />
         )}
       </section>

--- a/app/src/pages/schedule/[slug]/publish.tsx
+++ b/app/src/pages/schedule/[slug]/publish.tsx
@@ -11,6 +11,7 @@ import ServerSideErrorMessage from "../../../components/form/ServerSideErrorMess
 import AvailabilityResponses from "../../../components/schedule/AvailabilityResponses";
 import EditEventCard from "../../../components/schedule/publish/EditEventCard";
 import PublishEventCard from "../../../components/schedule/publish/PublishEventCard";
+import PublishedEventsNote from "../../../components/schedule/PublishedEventsNote";
 import ScheduleHeader from "../../../components/schedule/ScheduleHeader";
 import BackArrow from "../../../components/shared/BackArrow";
 import Loading from "../../../components/shared/Loading";
@@ -192,6 +193,11 @@ function Publish() {
 
   if (status === "unauthenticated") {
     return <Unauthenticated />;
+  }
+
+  // show a message if events have already been made for this schedule
+  if (schedule && schedule.events.length > 0) {
+    return <PublishedEventsNote slug={slug} />;
   }
 
   return (


### PR DESCRIPTION
- fixed bug in which adding the first availability was causing an `undefined` issue
- added new `PublishedEventsNote` component to show a warning message to those trying to access the `publish` and `availability` pages for schedules that already have published events
- hid the add availability button + publish events section to schedules with published events